### PR TITLE
BUGS-64: Birthday date selector doesn't show the selected date

### DIFF
--- a/PDTSimpleCalendar/PDTSimpleCalendarViewCell.h
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewCell.h
@@ -121,4 +121,9 @@
  */
 - (void)refreshCellColors;
 
+/**
+ *  Reflect the colors for the circle and the text, with setting the selected state
+ */
+- (void)setDateSelected:(BOOL)selected;
+
 @end

--- a/PDTSimpleCalendar/PDTSimpleCalendarViewCell.m
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewCell.m
@@ -115,7 +115,6 @@ const CGFloat PDTSimpleCalendarCircleSize = 32.0f;
 
 - (void)setDateSelected:(BOOL)selected
 {
-    [super setSelected:selected];
     [self setCircleColor:self.isToday selected:selected];
 }
 

--- a/PDTSimpleCalendar/PDTSimpleCalendarViewCell.m
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewCell.m
@@ -113,7 +113,7 @@ const CGFloat PDTSimpleCalendarCircleSize = 32.0f;
     [self setCircleColor:isToday selected:self.selected];
 }
 
-- (void)setSelected:(BOOL)selected
+- (void)setDateSelected:(BOOL)selected
 {
     [super setSelected:selected];
     [self setCircleColor:self.isToday selected:selected];

--- a/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
@@ -392,7 +392,7 @@ static const NSCalendarUnit kCalendarUnitYMD = NSCalendarUnitYear | NSCalendarUn
     }
 
     if (isSelected) {
-        [cell setSelected:isSelected];
+        [cell setDateSelected:isSelected];
     }
 
     //If the current Date is not enabled, or if the delegate explicitely specify custom colors

--- a/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
@@ -207,8 +207,8 @@ static const NSCalendarUnit kCalendarUnitYMD = NSCalendarUnitYear | NSCalendarUn
     }
 
 
-    [[self cellForItemAtDate:_selectedDate] setSelected:NO];
-    [[self cellForItemAtDate:startOfDay] setSelected:YES];
+    [[self cellForItemAtDate:_selectedDate] setDateSelected:NO];
+    [[self cellForItemAtDate:startOfDay] setDateSelected:YES];
 
     _selectedDate = startOfDay;
 


### PR DESCRIPTION
Link to story:
JIRA - https://storypark.atlassian.net/browse/BUGS-64
Linear - https://linear.app/storypark/issue/DNG-1226/families-ios-calendar-on-add-child-screen-doesnt-highlight-the-date

Link to families-ios PR: https://github.com/storypark/families-ios/pull/505

## Summary

How have you solved this issue? Are there any additional out-of-scope changes that have been made?

- 3rd party package https://github.com/jivesoftware/PDTSimpleCalendar is now forked under Storypark to get the fix done
- Fix failure to reflect background color of the selected date
- Overriding `setSelected` does not work as the function is called with losing selected state on `viewWillAppear`

## Areas where I'd like feedback

Please give a brief description of any concerns/blind spots.

## Testing/reproduction steps

How can we see this change? How can we reproduce this bug?<br>
Are there screenshots you can share?

## Scope

Could this change affect a lot of the codebase? (low, med, high)

## Code review rating system

Please preface your comments with a rating of how important this change is. You can familiarise yourself with the system in full [here](https://docs.google.com/document/d/1zPQA3DD8TbjJPJeN--BzYfbS3wIiufsvsea-GC_7i5w/edit).

| Value | Description |
| - | - |
| 1 | 💭 Non-blocking thoughts |
| 2 | 💬 A strong preference for a change, that can be overridden if a reason is given, or the change would take a long time to implement |
| 3 | ⚠️ There needs to be either a change or good discussion here |
| 4 | 🚨 This is a critical and compulsory change |